### PR TITLE
Mark TownyNameUpdater as Discontinued

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,10 +105,15 @@
 				<!--- TownyNameUpdater --->
 				<div style="background-color:#f2f2f2; border-radius:10px; padding:10px; margin-bottom: 5%">
 					<h5>TownyNameUpdater
+						<img src="https://img.shields.io/badge/-Discontinued-orange" align="right">
 						<img src="https://img.shields.io/github/v/tag/townyadvanced/townynameupdater.svg
-							?sort=semver&label=Latest Version&color=33C3F0&labelColor=888" align=right>
+							  ?sort=semver&label=Latest Version&color=33C3F0&labelColor=888" align="right">
 					</h5>
-					<p><i>Required for servers in online mode, for when players change their MC name.</i></p>
+					<p>
+						<i>Required for servers in online mode, prior to
+						<a href="https://github.com/TownyAdvanced/Towny/releases/tag/0.96.5.2">Towny 0.96.5.2</a>,
+						for when players change their MC name.</i>
+					</p>
 
 					<a class="button button-primary"
 					   href="https://github.com/TownyAdvanced/TownyNameUpdater">Github</a>


### PR DESCRIPTION
Adds a 'discontinued' shield to TownyNameUpdater, and specifies which versions don't need it.
![image](https://user-images.githubusercontent.com/2712890/101081156-50501680-356f-11eb-9939-8dbc738b6eb2.png)
